### PR TITLE
v2.0.3 CI skip

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "pyecharts" %}
+{% set version = "2.0.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyecharts-{{ version }}.tar.gz
+  sha256: 352a347c38c0bb122c1540bb2dd65cc534b3b8c9892c0e65c155d30102e824a1
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - jinja2
+    - prettytable
+    - simplejson
+
+test:
+  imports:
+    - pyecharts
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pyecharts.org/
+  dev_url: https://github.com/pyecharts/pyecharts
+  doc_url: https://pyecharts.org/#/en-us/
+  summary: Python options, make charting easier
+  description: |
+    Echarts is easy-to-use, highly interactive and highly performant 
+    javascript visualization library under Apache license. 
+    Since its first public release in 2013, it now dominates over 
+    74% of Chinese web front-end market. Yet Python is an expressive 
+    language and is loved by data science community. Combining the 
+    strength of both technologies, pyecharts is born.
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - ELundby45

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyecharts-{{ version }}.tar.gz
-  sha256: 352a347c38c0bb122c1540bb2dd65cc534b3b8c9892c0e65c155d30102e824a1
+  # TODO: PyPi tarball is missing licence as of v2.0.3
+  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyecharts-{{ version }}.tar.gz
+  url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 58962a89028b859a4e27ffceb3d08799367204bb479819bda091e38270891170
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
# pyecharts v2.0.3

upstream: https://github.com/pyecharts/pyecharts/tree/v2.0.3

## Actions
- Initiate new repository
- Generate skeleton recipe
- Update for our recipe standards

## Notes
- The github url is being used because the LICENSE file is not included in the PyPi tarball
- This is a new feedstock 
- This is destined for the snowflake channel