### PR TITLE
pyecharts 2.0.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyecharts" %}
-{% set version = "2.0.3" %}
+{% set version = "2.0.6" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ source:
   # TODO: PyPi tarball is missing licence as of v2.0.3
   # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyecharts-{{ version }}.tar.gz
   url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 58962a89028b859a4e27ffceb3d08799367204bb479819bda091e38270891170
+  sha256: c3a2ef58fe8c6722e9de610e0bbdb7c3a426973bf68a9c0f305f1a813070facb  
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
pyecharts 2.0.6 :snowflake:

**Destination channel:** Snowflake 

### Links

- [PKG-5635](https://anaconda.atlassian.net/browse/PKG-5635) 
- [Upstream repository](https://github.com/pyecharts/pyecharts/tree/v2.0.6)
- [Upstream changelog/diff](https://github.com/pyecharts/pyecharts/compare/v2.0.3...v2.0.6)
- Relevant dependency PRs:
  - dependency for https://github.com/AnacondaRecipes/streamlit-echarts-feedstock/pull/1

### Explanation of changes:

- pyecharts 2.0.3 was never built for py12, which is required for `streamlit-echarts`. Went ahead and bumped version to `2.0.6`


[PKG-5635]: https://anaconda.atlassian.net/browse/PKG-5635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ